### PR TITLE
Update power-port/power-ports check

### DIFF
--- a/nb-dt-import.py
+++ b/nb-dt-import.py
@@ -206,8 +206,10 @@ def createDeviceTypes(deviceTypes, nb):
                 print(f'Device Type Created: {dtSuccess.manufacturer.name} - {dtSuccess.model} - {dtSuccess.id}')
                 if "interfaces" in deviceType:
                     createInterfaces(deviceType["interfaces"], dtSuccess.id, nb)
-                if "power-ports" in deviceType or "power-port" in deviceType:
+                if "power-ports" in deviceType:
                     createPowerPorts(deviceType["power-ports"], dtSuccess.id, nb)
+                if "power-port" in deviceType:
+                    createPowerPorts(deviceType["power-port"], dtSuccess.id, nb)
                 if "console-ports" in deviceType:
                     createConsolePorts(deviceType["console-ports"], dtSuccess.id, nb)
                 if "power-outlets" in deviceType:

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 This library is intended to be your friend and help you import all the device-types defined within the the [NetBox Device Type Library Repository](https://github.com/netbox-community/devicetype-library).
 
-> This currently only works on NetBox v2.7.8.
+> Tested working with 2.7.8 and 2.8.8
 
 ## Getting Started
 


### PR DESCRIPTION
Split the check for 
```
if "power-ports" in deviceType or "power-port" in deviceType:
createPowerPorts(deviceType["power-ports"], dtSuccess.id, nb)
```
Into 

```
if "power-ports" in deviceType:
createPowerPorts(deviceType["power-ports"], dtSuccess.id, nb)
if "power-port" in deviceType:
createPowerPorts(deviceType["power-port"], dtSuccess.id, nb)
```
Because it was causing issues

Otherwise this also worked without issue on `v2.8.8`!

Thanks for your work, this is the best importer I've found yet! Handles existing manufacturers / device types / ports flawlessly!