### PR TITLE
fix: error on unambigious powerport when trying to create power outlets

### DIFF
--- a/nb-dt-import.py
+++ b/nb-dt-import.py
@@ -178,13 +178,16 @@ def createPowerOutlets(poweroutlets, deviceType, nb):
             if poGet:
                 print(f'Power Outlet Template Exists: {poGet.name} - {poGet.type} - {poGet.device_type.id} - {poGet.id}')
             else:
-                ppGet = nb.dcim.power_port_templates.get(devicetype_id=deviceType)
-                if ppGet:
-                    poweroutlet["power_port"] = ppGet.id
-                    poweroutlet["device_type"] = deviceType
-                    poSuccess = nb.dcim.power_outlet_templates.create(poweroutlet)
-                    print(f'Power Outlet Created: {poSuccess.name} - {poSuccess.type} - {poSuccess.device_type.id} - {poSuccess.id}')
-                counter.update({'updated':1})
+                try:
+                    ppGet = nb.dcim.power_port_templates.get(devicetype_id=deviceType)
+                    if ppGet:
+                        poweroutlet["power_port"] = ppGet.id
+                        poweroutlet["device_type"] = deviceType
+                        poSuccess = nb.dcim.power_outlet_templates.create(poweroutlet)
+                        print(f'Power Outlet Created: {poSuccess.name} - {poSuccess.type} - {poSuccess.device_type.id} - {poSuccess.id}')
+                    counter.update({'updated':1})
+                except:
+                    print(f'Error assining Power Port to Power Outlet in Outlet: {poweroutlet["name"]}')
         except pynetbox.RequestError as e:
             print(e.error) 
 

--- a/nb-dt-import.py
+++ b/nb-dt-import.py
@@ -185,9 +185,12 @@ def createPowerOutlets(poweroutlets, deviceType, nb):
                         poweroutlet["device_type"] = deviceType
                         poSuccess = nb.dcim.power_outlet_templates.create(poweroutlet)
                         print(f'Power Outlet Created: {poSuccess.name} - {poSuccess.type} - {poSuccess.device_type.id} - {poSuccess.id}')
-                    counter.update({'updated':1})
+                        counter.update({'updated':1})
                 except:
-                    print(f'Error assining Power Port to Power Outlet in Outlet: {poweroutlet["name"]}')
+                    poweroutlet["device_type"] = deviceType
+                    poSuccess = nb.dcim.power_outlet_templates.create(poweroutlet)
+                    print(f'Power Outlet Created: {poSuccess.name} - {poSuccess.type} - {poSuccess.device_type.id} - {poSuccess.id}')
+                    counter.update({'updated':1})
         except pynetbox.RequestError as e:
             print(e.error) 
 


### PR DESCRIPTION
There is an APC template in the device-type library that would always cause this to fail. The APC AP7721. 

Problem is there are two power ports, and the template's power outlets are not assigned to either of them. So the `.get()` on https://github.com/minitriga/Netbox-Device-Type-Library-Import/blob/master/nb-dt-import.py#L181 would error because it returned two results instead of one unambiguous one. 

I currently just wrapped it in a try/except where it spits out an error that it couldn't add that power outlet because its not sure which power port to assign it to. 

I noticed in the Netbox UI, however, that power port is not a required field for power outlets. So I want to see if I can get this to work to add the power outlet without assigning a port, therefore the current WIP status.