### PR TITLE
Add CLI option for custom git URL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Editor
+.vscode

--- a/nb-dt-import.py
+++ b/nb-dt-import.py
@@ -3,13 +3,12 @@ from collections import Counter
 import yaml, pynetbox, glob, argparse, os, settings
 
 parser = argparse.ArgumentParser(description='Import Netbox Device Types')
-parser.add_argument('--vendor', nargs='+')
-
+parser.add_argument('--vendor', nargs='+', help="List of vendors to import eg. apc cisco")
+parser.add_argument('--url','--git', default='https://github.com/netbox-community/devicetype-library.git', help="Git URL with valid Device Type YAML files")
 args = parser.parse_args()
 
 cwd = os.getcwd()
 counter = Counter(added=0,updated=0,manufacturer=0)
-url = 'https://github.com/netbox-community/devicetype-library.git'
 nbUrl = settings.NETBOX_URL
 nbToken = settings.NETBOX_TOKEN
 
@@ -249,10 +248,10 @@ try:
         update_package('./repo')
         print(msg)
     else:
-        repo = Repo.clone_from(url, os.path.join(cwd, 'repo'))
+        repo = Repo.clone_from(args.url, os.path.join(cwd, 'repo'))
         print("Package Installed")
 except exc.GitCommandError as error:
-    print("Couldn't clone {} ({})".format(url, error))
+    print("Couldn't clone {} ({})".format(args.url, error))
 
 nb = pynetbox.api(nbUrl, token=nbToken)
 

--- a/nb-dt-import.py
+++ b/nb-dt-import.py
@@ -52,7 +52,7 @@ def readYAMl(files):
             manufacturer = data['manufacturer']
             data['manufacturer'] = {}
             data['manufacturer']['name'] = manufacturer
-            data['manufacturer']['slug'] = manufacturer.lower()
+            data['manufacturer']['slug'] = manufacturer.lower().replace(" ", "")
         deviceTypes.append(data)
         manufacturers.append(manufacturer)
     return deviceTypes

--- a/nb-dt-import.py
+++ b/nb-dt-import.py
@@ -48,6 +48,7 @@ def readYAMl(files):
                 data = yaml.safe_load(stream)
             except yaml.YAMLError as exc:
                 print(exc)
+                return deviceTypes
             manufacturer = data['manufacturer']
             data['manufacturer'] = {}
             data['manufacturer']['name'] = manufacturer

--- a/nb-dt-import.py
+++ b/nb-dt-import.py
@@ -17,7 +17,7 @@ def update_package(path: str):
         repo = Repo(path)
         if repo.remotes.origin.url.endswith('.git'):
             repo.remotes.origin.pull()
-            print("Pulled Repo")
+            print(f"Pulled Repo {repo.remotes.origin.url}")
     except exc.InvalidGitRepositoryError:
         pass
 
@@ -245,12 +245,11 @@ def createDeviceTypes(deviceTypes, nb):
 
 try:
     if os.path.isdir('./repo'):
-        msg = 'Package devicetype-library is already installed, updating'
+        print(f"Package devicetype-library is already installed, updating {os.path.join(cwd, 'repo')}")
         update_package('./repo')
-        print(msg)
     else:
         repo = Repo.clone_from(args.url, os.path.join(cwd, 'repo'))
-        print("Package Installed")
+        print(f"Package Installed {repo.remotes.origin.url}")
 except exc.GitCommandError as error:
     print("Couldn't clone {} ({})".format(args.url, error))
 

--- a/nb-dt-import.py
+++ b/nb-dt-import.py
@@ -48,7 +48,7 @@ def readYAMl(files):
                 data = yaml.safe_load(stream)
             except yaml.YAMLError as exc:
                 print(exc)
-                return deviceTypes
+                continue
             manufacturer = data['manufacturer']
             data['manufacturer'] = {}
             data['manufacturer']['name'] = manufacturer


### PR DESCRIPTION
Added CLI option for the git URL used, so it can be pointed to forks of devicetype-library and added some help text to the CLI options and the output so it's clear what is being used as a data source.  Also fixed a lint issue in readYAML if there is an exception just continue to the next file instead of trying to use the uninitialized data.