### PR TITLE
Added '--part_number' option; fixed vendor slugs

### DIFF
--- a/nb-dt-import.py
+++ b/nb-dt-import.py
@@ -27,7 +27,8 @@ def getFiles(vendors=None):
     discoveredVendors = []
     for r, d, f in os.walk('./repo/device-types/'):
             for folder in d:
-                if (vendors is None or folder.upper() in vendors):
+                if folder.lower() != 'testing':
+                    if (vendors is None or folder.upper() in vendors):
                         discoveredVendors.append({'name': folder, 'slug': folder.lower().replace(" ", "")})
                         if args.part_number is None:
                             files.extend(glob.glob('./repo/device-types/' + folder + '/*.yaml'))


### PR DESCRIPTION
Added the args '--part_number' to be able to import only one or more devices, in stead of all of one vendor.
Best is to combine with the '--vendor' arg

also fixed an issue where the 'slug' contained spaces for vendors

cleaned up some redundant code