### PR TITLE
match 'vendors' arg between docs and code

### DIFF
--- a/nb-dt-import.py
+++ b/nb-dt-import.py
@@ -9,7 +9,7 @@ import settings
 
 REPO_URL = 'https://github.com/netbox-community/devicetype-library.git'
 parser = argparse.ArgumentParser(description='Import Netbox Device Types')
-parser.add_argument('--vendor', nargs='+',
+parser.add_argument('--vendors', nargs='+',
                     help="List of vendors to import eg. apc cisco")
 parser.add_argument('--url', '--git', default=REPO_URL,
                     help="Git URL with valid Device Type YAML files")
@@ -338,8 +338,8 @@ except exc.GitCommandError as error:
 
 nb = pynetbox.api(nbUrl, token=nbToken)
 
-if args.vendor is None:
-    print("No Vendor Specified, Gathering All Device-Types")
+if args.vendors is None:
+    print("No Vendors Specified, Gathering All Device-Types")
     files, vendors = getFiles()
     print(str(len(vendors)) + " Vendors Found")
     print(str(len(files)) + " Device-Types Found")


### PR DESCRIPTION
the arg was called vendor (singular), while most of the code and the readme mentioned 'vendors' (plural) and the arg in fact supports multiple vendors.