### PR TITLE
docker build  + add vendors choices as env var

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.9-alpine
+COPY requirements.txt .
+RUN apk add --no-cache git
+RUN pip3 install -r requirements.txt
+
+# default
+ENV REPO_URL=https://github.com/netbox-community/devicetype-library.git
+WORKDIR /app
+COPY *.py ./
+
+# -u to avoid stdout buffering
+CMD ["python","-u","nb-dt-import.py"]

--- a/README.md
+++ b/README.md
@@ -64,6 +64,29 @@ To import only device by APC, for example:
 ./nb-dt-import.py --vendors apc juniper
 ```
 
+## Docker build
+
+It's possible to use this project as a docker container. 
+
+To build : 
+
+```
+docker build -t netbox-devicetype-import-library .
+```
+
+The container supports the following env var as configuration : 
+
+- `REPO_URL`, the repo to look for device types (defaults to _https://github.com/netbox-community/devicetype-library.git_)
+- `NETBOX_URL`, used to access netbox
+- `NETBOX_TOKEN`, token for accessing netbox
+- `VENDORS`, a space-separated list of vendors to import (defaults to None)
+
+To run : 
+
+```
+docker run -e "NETBOX_URL=http://netbox:8080/" -e "NETBOX_TOKEN=98765434567890" netbox-devicetype-import-library
+```
+
 ## 🧑‍💻 Contributing
 
 We're happy about any pull requests!

--- a/nb-dt-import.py
+++ b/nb-dt-import.py
@@ -10,8 +10,9 @@ import os
 import settings
 
 REPO_URL = settings.REPO_URL
+
 parser = argparse.ArgumentParser(description='Import Netbox Device Types')
-parser.add_argument('--vendors', nargs='+',
+parser.add_argument('--vendors', nargs='+', default=settings.VENDORS,
                     help="List of vendors to import eg. apc cisco")
 parser.add_argument('--url', '--git', default=REPO_URL,
                     help="Git URL with valid Device Type YAML files")

--- a/settings.py
+++ b/settings.py
@@ -6,6 +6,12 @@ REPO_URL = str(os.getenv("REPO_URL"))
 NETBOX_URL = str(os.getenv("NETBOX_URL"))
 NETBOX_TOKEN = str(os.getenv("NETBOX_TOKEN"))
 
+# optionnally load vendors through a space separated list as env var
+try:
+    VENDORS = os.getenv("VENDORS").split(" ") 
+except AttributeError:
+    VENDORS = None
+
 MANDATORY_ENV_VARS = ["REPO_URL", "NETBOX_URL", "NETBOX_TOKEN"]
 
 for var in MANDATORY_ENV_VARS:


### PR DESCRIPTION
Hi,

This PR adds a Dockerfile making possible to run the project as a container. 
It also enables the selection of vendors through an `VENDORS` env var, with the same behavior as the `--vendors` arg, so that everything is configurable through env var. 

Regarding the documentation, I think a new section could be added, but I wanted to check if you were ok with the feature beforehand. 

thx!
