### PR TITLE
docker image CI

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,6 +1,7 @@
 name: example-docker-ci
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - 'master'

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,27 @@
+name: example-docker-ci
+
+on:
+  push:
+    branches:
+      - 'master'
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v1 
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+      -
+        name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: k0rventen/netbox-device-type-library-import:latest
+      -
+        name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}


### PR DESCRIPTION
Hi. Following #23, here is a very simple stage using Actions that builds the image from master and pushes to docker hub. 

It should _not_ be merged as-is, because it contains a hard reference to my docker account. 

To set it up on your side, you would need to add two secrets to this repository, `DOCKER_USER` & `DOCKER_TOKEN` (the token being a dedicated access token).

And change the full path of the tag to match your account. 

Cheers,