### PR TITLE
Bumped requests version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ progressbar2==3.47.0
 pynetbox==4.2.5
 python-utils==2.3.0
 PyYAML==5.4
-requests==2.22.0
+requests==2.25.1
 six==1.14.0
 smmap2==2.0.5
 urllib3==1.26.5


### PR DESCRIPTION
Bumped requests library to 2.25.1 to keep compatibility with Python 3.5 while still working with urllib3-1.26.5 that was introduced in 3c12cb5

Fixes #28 