### PR TITLE
Fixes #34: Change Vendor Delimiter

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,10 @@ To import only device by APC, for example:
 ./nb-dt-import.py --vendors apc
 ```
 
-`--vendors` can also accept a space separated list of vendors if you want to import multiple. 
+`--vendors` can also accept a comma separated list of vendors if you want to import multiple. 
 
 ```
-./nb-dt-import.py --vendors apc juniper
+./nb-dt-import.py --vendors apc,juniper
 ```
 
 ## Docker build
@@ -80,7 +80,7 @@ The container supports the following env var as configuration :
 - `REPO_BRANCH`, the branch to check out if appropriate, defaults to master.
 - `NETBOX_URL`, used to access netbox
 - `NETBOX_TOKEN`, token for accessing netbox
-- `VENDORS`, a space-separated list of vendors to import (defaults to None)
+- `VENDORS`, a comma-separated list of vendors to import (defaults to None)
 
 To run : 
 

--- a/settings.py
+++ b/settings.py
@@ -9,7 +9,7 @@ NETBOX_TOKEN = os.getenv("NETBOX_TOKEN")
 IGNORE_SSL_ERRORS = (os.getenv("IGNORE_SSL_ERRORS", "False") == "True")
 
 # optionnally load vendors through a space separated list as env var
-VENDORS = os.getenv("VENDORS", "").split()
+VENDORS = os.getenv("VENDORS", "").split(",")
 
 # optionally load device types through a space separated list as env var
 SLUGS = os.getenv("SLUGS", "").split()


### PR DESCRIPTION
Changed the split-delimiter from empty (white spaces) to comma. Because with white spaces as delimiter all vendors with a white space in their name cannot be imported (quotes didn't work in ENV strings).

For example:
`docker run -e "VENDORS=Cisco Palo Alto " netbox-devicetype-import-library
`
This would be trated as three vendors.

Instead with comma as delimiter:
`docker run -e "VENDORS=Cisco,Palo Alto" netbox-devicetype-import-library
`
Would be treated as wo vendors like it should.

Merging this change means, that you have to use a comma separated vendor list instead of white space separated from now on.
But all the vendors with white spaces in thier name will then be supported as well (tested it already).

Fixes #34 