### PR TITLE
Fixes #8: Strip all not supported chars in manufacturer slug

### DIFF
--- a/nb-dt-import.py
+++ b/nb-dt-import.py
@@ -9,6 +9,7 @@ import argparse
 import os
 import settings
 import sys
+import re
 
 
 counter = Counter(added=0, updated=0, manufacturer=0)
@@ -26,7 +27,7 @@ def update_package(path: str, branch: str):
 
 
 def slugFormat(name):
-    return name.lower().replace(' ', '_')
+    return re.sub('\W+','-', name.lower())
 
 YAML_EXTENSIONS = ['yml', 'yaml']
 


### PR DESCRIPTION
There is a problem with stripping special characters from manufacturers names for the slug.
For example: "Rohde & Schwarz" would be stripped down to "rohde_&_schwarz" which is not a clean solution.
When manually creating a manufacturer in Netbox with that name, Netbox strips the slug down to "rohde-schwarz" which is much cleaner.

So I implemented a change which strips all special characters (and white spaces) and replaces them with a single hyphen (-). This solves the problem of special chars other than white spaces, and also when there are multiple behind each other.
Also changed the underscore to hyphen as the Netbox uses hyphens by default (avoiding problems with existing manufacturer entries).

A few examples:
`Rohde & Schwarz --> rohde-schwarz`
`Palo Alto --> palo-alto`
`Example - Vendor --> example-vendor`

Technical explanation: Used the regular expression module with `\W+` (equivalent to `[^a-zA-Z0-9_]`) as this matches any non-word chars.

Fixes #8 