### PR TITLE
Support for ghcr.io container registry.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,88 @@
+# Git
+.git
+.gitignore
+.gitattributes
+
+# CI
+.codeclimate.yml
+.travis.yml
+.taskcluster.yml
+
+# Docker
+docker-compose.yml
+Dockerfile
+.docker
+.dockerignore
+
+# Byte-compiled / optimized / DLL files
+**/__pycache__/
+**/*.py[cod]
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.cache
+nosetests.xml
+coverage.xml
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Virtual environment
+.env
+.venv/
+venv/
+
+# PyCharm
+.idea
+
+# Python mode for VIM
+.ropeproject
+**/.ropeproject
+
+# Vim swap files
+**/*.swp
+
+# VS Code
+.vscode/

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,28 +1,59 @@
-name: example-docker-ci
+name: ci
 
 on:
-  workflow_dispatch:
   push:
     branches:
       - 'master'
+      - 'main'
+  pull_request:
+    branches:
+      - 'master'
+      - 'main'
+  workflow_dispatch:
+  release:
+    types: [published, edited]
 
 jobs:
-  docker:
+  build-and-push-images:
     runs-on: ubuntu-latest
     steps:
       -
-        name: Login to DockerHub
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: |
+            ghcr.io/minitriga/Netbox-Device-Type-Library-Import
+          tags: |
+            type=raw,value=latest,enable=${{ endsWith(github.ref, github.event.repository.default_branch) }}
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}
+            type=semver,pattern={{major}}.{{minor}}
+      - 
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Login to GitHub Container Registry
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v1 
         with:
-          username: ${{ secrets.DOCKER_USER }}
-          password: ${{ secrets.DOCKER_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       -
         name: Build and push
-        id: docker_build
         uses: docker/build-push-action@v2
         with:
-          push: true
-          tags: k0rventen/netbox-device-type-library-import:latest
-      -
-        name: Image digest
-        run: echo ${{ steps.docker_build.outputs.digest }}
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          platforms: linux/amd64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,16 @@
 FROM python:3.9-alpine
-COPY requirements.txt .
-RUN apk add --no-cache git
-RUN pip3 install -r requirements.txt
 
-# default
 ENV REPO_URL=https://github.com/netbox-community/devicetype-library.git
 WORKDIR /app
+COPY requirements.txt .
+
+# Install dependencies
+RUN apk add --no-cache git ca-certificates && \
+    python3 -m pip install --upgrade pip && \
+    pip3 install -r requirements.txt
+
+# Copy over src code
 COPY *.py ./
 
 # -u to avoid stdout buffering
-CMD ["python","-u","nb-dt-import.py"]
+CMD ["python3","-u","nb-dt-import.py"]

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ To build :
 docker build -t netbox-devicetype-import-library .
 ```
 
-Alternative you can pull a pre-build image from Github Container Registry (ghcr.io):
+Alternatively you can pull a pre-built image from Github Container Registry (ghcr.io):
 
 ```
 docker pull ghcr.io/minitriga/Netbox-Device-Type-Library-Import

--- a/README.md
+++ b/README.md
@@ -74,6 +74,12 @@ To build :
 docker build -t netbox-devicetype-import-library .
 ```
 
+Alternative you can pull a pre-build image from Github Container Registry (ghcr.io):
+
+```
+docker pull ghcr.io/minitriga/Netbox-Device-Type-Library-Import
+```
+
 The container supports the following env var as configuration : 
 
 - `REPO_URL`, the repo to look for device types (defaults to _https://github.com/netbox-community/devicetype-library.git_)


### PR DESCRIPTION
#### Docker improvements:
* Added .dockerignore file made for Python projects.
* Cleanup of Dockerfile
* Upgrade pip before trying to install any dependency.

#### Improvements to Github Workflows:
* Added support for building, tagging and pushing an image to `ghcr.io`
* Added support for running Docker Builds for Pull Requests.
* Any pushes to master/main will get tagged as "latest".
* Support for semver tags.
* Image will be tagged as: `ghcr.io/minitriga/Netbox-Device-Type-Library-Import`
* Docker Image will *Only* be pushed when a new tag is created or when changes are committed into `master`/`main` branch.

#### TODO:
* @minitriga Will need to follow the instructions from ( https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-to-the-container-registry ) to create a Github Token for the image to be pushed.