### PR TITLE
feat(docker): Move script to entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,15 @@
 FROM python:3.9-alpine
 
+# Source repository ENV variables
 ENV REPO_URL=https://github.com/netbox-community/devicetype-library.git
+ENV REPO_BRANCH=master
+
+# Netbox ENV variables
+ENV NETBOX_URL=''
+ENV NETBOX_TOKEN=''
+ENV REPO_BRANCH=master
+ENV IGNORE_SSL_ERRORS=False
+
 WORKDIR /app
 COPY requirements.txt .
 
@@ -13,4 +22,4 @@ RUN apk add --no-cache git ca-certificates && \
 COPY *.py ./
 
 # -u to avoid stdout buffering
-CMD ["python3","-u","nb-dt-import.py"]
+ENTRYPOINT ["python3","-u","nb-dt-import.py"]

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This script will clone a copy of the `netbox-community/devicetype-library` repos
 
 1. This script is written in Python, so lets setup a virtual environment.
 
-```
+```bash
 git clone https://github.com/netbox-community/Device-Type-Library-Import.git
 cd Netbox-Device-Type-Library-Import
 python3 -m venv venv
@@ -21,7 +21,7 @@ source venv/bin/activate
 
 2. Now that we have the basics setup, we'll need to install the requirements.
 
-```
+```bash
 pip install -r requirements.txt
 ```
 
@@ -29,7 +29,7 @@ pip install -r requirements.txt
 
 Copy the existing `.env.example` to your own `.env` file, and fill in the variables.
 
-```
+```bash
 cp .env.example .env
 vim .env
 ```
@@ -40,7 +40,7 @@ Finally, we are able to execute the script and import some device templates!
 
 To use the script, simply execute the script as follows. Make sure you're still in the activated virtual environment we created before.
 
-```
+```bash
 ./nb-dt-import.py
 ```
 
@@ -54,13 +54,13 @@ This script currently accepts a list of vendors as an arugment, so that you can 
 
 To import only device by APC, for example:
 
-```
+```bash
 ./nb-dt-import.py --vendors apc
 ```
 
 `--vendors` can also accept a comma separated list of vendors if you want to import multiple.
 
-```
+```bash
 ./nb-dt-import.py --vendors apc,juniper
 ```
 
@@ -70,13 +70,13 @@ It's possible to use this project as a docker container.
 
 To build :
 
-```
+```bash
 docker build -t netbox-devicetype-import-library .
 ```
 
 Alternatively you can pull a pre-built image from Github Container Registry (ghcr.io):
 
-```
+```bash
 docker pull ghcr.io/minitriga/netbox-device-type-library-import
 ```
 
@@ -90,8 +90,23 @@ The container supports the following env var as configuration :
 
 To run :
 
-```
+```bash
 docker run -e "NETBOX_URL=http://netbox:8080/" -e "NETBOX_TOKEN=98765434567890" ghcr.io/minitriga/netbox-device-type-library-import
+```
+
+Like for python script execution, an env file can be created and used with docker command:
+
+```bash
+cp .env.example env-docker
+vim env-docker
+
+docker run --rm --env-file=env-docker ghcr.io/minitriga/netbox-device-type-library-import
+```
+
+To make it similar to python script, you can use the `--vendors` knob in the cli
+
+```bash
+docker run --rm --env-file=env-docker ghcr.io/minitriga/netbox-device-type-library-import --vendors Arista,Juniper
 ```
 
 ## 🧑‍💻 Contributing


### PR DESCRIPTION
## Overview

Moving script to entrypoint make it easier to leverage script argument from CLI instead of always leveraging ENV variable.

```
docker run --rm --env-file=env-develop \
  ghcr.io/minitriga/netbox-device-type-library-import --vendors Arista,Juniper
```

`ENV` variable approach is unchanged and can still be used.

## Changes:

- Update `Dockerfile` for `ENTRYPOINT`
- Update `Dockerfile` to explicitely set `ENV` names
- Update documentation accordingly (`README.md`)
- Add type to all code blocks in `README.md`