### PR TITLE
Hot fix to allow filtering via slug

### DIFF
--- a/repo.py
+++ b/repo.py
@@ -98,6 +98,9 @@ class DTLRepo:
                 # Save file location to resolve any relative paths for images
                 data['src'] = file
 
+            if data.get('slug') is None:
+                continue
+
             if slugs and True not in [True if s.casefold() in data['slug'].casefold() else False for s in slugs]:
                 self.handle.verbose_log(f"Skipping {data['model']}")
                 continue


### PR DESCRIPTION
Current implementation does not allow filtering by slug. If slug is specified, it returns an error. A quick fix for that is to check that `data['slug]` is not `None`. If it is, it will end the loop and go for the next iteration.