### PR TITLE
fix: really disable ssl warnings in console

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 This library is intended to be your friend and help you import all the device-types defined within the the [NetBox Device Type Library Repository](https://github.com/netbox-community/devicetype-library).
 
-> Tested working with 2.9.4, 2.10.4
-
 ## 🪄 Description
 
 This script will clone a copy of the `netbox-community/devicetype-library` repository to your machine to allow it to import the device types you would like without copy and pasting them into the Netbox UI.

--- a/netbox_api.py
+++ b/netbox_api.py
@@ -34,7 +34,7 @@ class NetBox:
             self.netbox = pynetbox.api(self.url, token=self.token)
             if self.ignore_ssl:
                 self.handle.verbose_log("IGNORE_SSL_ERRORS is True, catching exception and disabling SSL verification.")
-                #requests.packages.urllib3.disable_warnings()
+                requests.packages.urllib3.disable_warnings()
                 self.netbox.http_session.verify = False
         except Exception as e:
             self.handle.exception("Exception", 'NetBox API Error', e)


### PR DESCRIPTION
- Enable hiding the `urllib3` warnings if `ignore_ssl` env var is enabled. Previously, when that env var option is enabled the import would work, but the output would be flooded with `urllib3` warnings making the normal output almost unreadable.
- Remove "tested with.." note from README, just leads to confusion and is difficult to keep up-to-date. Just ran this with `3.7.0` and it successfully updated some device-types, imported new device-types, and even added images to some existing device-types. So I'd say its fine for the latest version of Netbox as well.