### PR TITLE
repo: remove check for '.git' at end of git remote

### DIFF
--- a/repo.py
+++ b/repo.py
@@ -43,9 +43,6 @@ class DTLRepo:
             self.handle.log("Package devicetype-library is already installed, "
                             + f"updating {self.get_absolute_path()}")
             self.repo = Repo(self.repo_path)
-            if not self.repo.remotes.origin.url.endswith('.git'):
-                self.handle.exception("GitInvalidRepositoryError", self.repo.remotes.origin.url,
-                                      f"Origin URL {self.repo.remotes.origin.url} does not end with .git")
             self.repo.remotes.origin.pull()
             self.repo.git.checkout(self.branch)
             self.handle.verbose_log(


### PR DESCRIPTION
I can't think of a reason to enforce this. When script is run by default (at least with git version 2.42.0), there is no '.git' at the end of the remote.

Here is what 'git remote -v' shows:
  origin  https://github.com/netbox-community/devicetype-library

After removing the check, we can run the script multiple times in a row without deleting the 'repo' folder.

Fixes issue #129