### PR TITLE
remove .git

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 NETBOX_URL=
 NETBOX_TOKEN=
-REPO_URL=https://github.com/netbox-community/devicetype-library.git
+REPO_URL=https://github.com/netbox-community/devicetype-library
 REPO_BRANCH=master
 IGNORE_SSL_ERRORS=False
 #SLUGS=c9300-48u isr4431 isr4331


### PR DESCRIPTION
update URL path so it can be downloaded

as mention in [issues#129](https://github.com/netbox-community/Device-Type-Library-Import/issues/129)