### PR TITLE
Add configuration option for using system truststore

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,4 +3,5 @@ NETBOX_TOKEN=
 REPO_URL=https://github.com/netbox-community/devicetype-library.git
 REPO_BRANCH=master
 IGNORE_SSL_ERRORS=False
+#REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt # you should enable this if you are running on a linux system
 #SLUGS=c9300-48u isr4431 isr4331

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ The container supports the following env var as configuration :
 - `NETBOX_URL`, used to access netbox
 - `NETBOX_TOKEN`, token for accessing netbox
 - `VENDORS`, a comma-separated list of vendors to import (defaults to None)
+- `REQUESTS_CA_BUNDLE`, path to a CA_BUNDLE for validation if you are using self-signed certificates(file must be included in the container)
 
 To run :
 


### PR DESCRIPTION
This is a small change to provide a configuration option to use the linux system truststore if required like in a business environment with own pki infrastructure. 
It adds an commented option to the .env.example. This keeps compability for non linux based setups but saves everyone using this project the time to search for the correct parameter for the requests librarary or from disabling verification at all. 
I also updated the Readme for the container.
Using a default config option of the requests library this should work if you include the corresponding CA_BUNDLE for your organization in the container. 
All in all its an little quality of life change. If I need to add something more feel free to give me some feedback and I'll will look into improving this PR.