### PR TITLE
Fix filter statement when importing devices

### DIFF
--- a/netbox_api.py
+++ b/netbox_api.py
@@ -194,16 +194,16 @@ class DeviceTypes:
         return {str(item): item for item in self.netbox.dcim.device_types.all()}
 
     def get_power_ports(self, device_type):
-        return {str(item): item for item in self.netbox.dcim.power_port_templates.filter(devicetype_id=device_type)}
+        return {str(item): item for item in self.netbox.dcim.power_port_templates.filter(device_type_id=device_type)}
 
     def get_rear_ports(self, device_type):
-        return {str(item): item for item in self.netbox.dcim.rear_port_templates.filter(devicetype_id=device_type)}
+        return {str(item): item for item in self.netbox.dcim.rear_port_templates.filter(device_type_id=device_type)}
 
     def get_module_power_ports(self, module_type):
-        return {str(item): item for item in self.netbox.dcim.power_port_templates.filter(moduletype_id=module_type)}
+        return {str(item): item for item in self.netbox.dcim.power_port_templates.filter(module_type_id=module_type)}
 
     def get_module_rear_ports(self, module_type):
-        return {str(item): item for item in self.netbox.dcim.rear_port_templates.filter(moduletype_id=module_type)}
+        return {str(item): item for item in self.netbox.dcim.rear_port_templates.filter(module_type_id=module_type)}
 
     def get_device_type_ports_to_create(self, dcim_ports, device_type, existing_ports):
         to_create = [port for port in dcim_ports if port['name'] not in existing_ports]
@@ -221,7 +221,7 @@ class DeviceTypes:
 
     def create_interfaces(self, interfaces, device_type):
         existing_interfaces = {str(item): item for item in self.netbox.dcim.interface_templates.filter(
-            devicetype_id=device_type)}
+            device_type_id=device_type)}
         to_create = self.get_device_type_ports_to_create(
             interfaces, device_type, existing_interfaces)
 
@@ -248,7 +248,7 @@ class DeviceTypes:
                 self.handle.log(f"Error '{excep.error}' creating Power Port")
 
     def create_console_ports(self, console_ports, device_type):
-        existing_console_ports = {str(item): item for item in self.netbox.dcim.console_port_templates.filter(devicetype_id=device_type)}
+        existing_console_ports = {str(item): item for item in self.netbox.dcim.console_port_templates.filter(device_type_id=device_type)}
         to_create = self.get_device_type_ports_to_create(console_ports, device_type, existing_console_ports)
 
         if to_create:
@@ -261,7 +261,7 @@ class DeviceTypes:
                 self.handle.log(f"Error '{excep.error}' creating Console Port")
 
     def create_power_outlets(self, power_outlets, device_type):
-        existing_power_outlets = {str(item): item for item in self.netbox.dcim.power_outlet_templates.filter(devicetype_id=device_type)}
+        existing_power_outlets = {str(item): item for item in self.netbox.dcim.power_outlet_templates.filter(device_type_id=device_type)}
         to_create = self.get_device_type_ports_to_create(power_outlets, device_type, existing_power_outlets)
 
         if to_create:
@@ -282,7 +282,7 @@ class DeviceTypes:
                 self.handle.log(f"Error '{excep.error}' creating Power Outlet")
 
     def create_console_server_ports(self, console_server_ports, device_type):
-        existing_console_server_ports = {str(item): item for item in self.netbox.dcim.console_server_port_templates.filter(devicetype_id=device_type)}
+        existing_console_server_ports = {str(item): item for item in self.netbox.dcim.console_server_port_templates.filter(device_type_id=device_type)}
         to_create = self.get_device_type_ports_to_create(console_server_ports, device_type, existing_console_server_ports)
 
         if to_create:
@@ -308,7 +308,7 @@ class DeviceTypes:
                 self.handle.log(f"Error '{excep.error}' creating Rear Port")
 
     def create_front_ports(self, front_ports, device_type):
-        existing_front_ports = {str(item): item for item in self.netbox.dcim.front_port_templates.filter(devicetype_id=device_type)}
+        existing_front_ports = {str(item): item for item in self.netbox.dcim.front_port_templates.filter(device_type_id=device_type)}
         to_create = self.get_device_type_ports_to_create(front_ports, device_type, existing_front_ports)
 
         if to_create:
@@ -330,7 +330,7 @@ class DeviceTypes:
                 self.handle.log(f"Error '{excep.error}' creating Front Port")
 
     def create_device_bays(self, device_bays, device_type):
-        existing_device_bays = {str(item): item for item in self.netbox.dcim.device_bay_templates.filter(devicetype_id=device_type)}
+        existing_device_bays = {str(item): item for item in self.netbox.dcim.device_bay_templates.filter(device_type_id=device_type)}
         to_create = self.get_device_type_ports_to_create(device_bays, device_type, existing_device_bays)
 
         if to_create:
@@ -343,7 +343,7 @@ class DeviceTypes:
                 self.handle.log(f"Error '{excep.error}' creating Device Bay")
 
     def create_module_bays(self, module_bays, device_type):
-        existing_module_bays = {str(item): item for item in self.netbox.dcim.module_bay_templates.filter(devicetype_id=device_type)}
+        existing_module_bays = {str(item): item for item in self.netbox.dcim.module_bay_templates.filter(device_type_id=device_type)}
         to_create = self.get_device_type_ports_to_create(module_bays, device_type, existing_module_bays)
 
         if to_create:
@@ -356,7 +356,7 @@ class DeviceTypes:
                 self.handle.log(f"Error '{excep.error}' creating Module Bay")
 
     def create_module_interfaces(self, module_interfaces, module_type):
-        existing_interfaces = {str(item): item for item in self.netbox.dcim.interface_templates.filter(moduletype_id=module_type)}
+        existing_interfaces = {str(item): item for item in self.netbox.dcim.interface_templates.filter(module_type_id=module_type)}
         to_create = self.get_module_type_ports_to_create(module_interfaces, module_type, existing_interfaces)
 
         if to_create:
@@ -382,7 +382,7 @@ class DeviceTypes:
                 self.handle.log(f"Error '{excep.error}' creating Module Power Port")
 
     def create_module_console_ports(self, console_ports, module_type):
-        existing_console_ports = {str(item): item for item in self.netbox.dcim.console_port_templates.filter(moduletype_id=module_type)}
+        existing_console_ports = {str(item): item for item in self.netbox.dcim.console_port_templates.filter(module_type_id=module_type)}
         to_create = self.get_module_type_ports_to_create(console_ports, module_type, existing_console_ports)
 
         if to_create:
@@ -395,7 +395,7 @@ class DeviceTypes:
                 self.handle.log(f"Error '{excep.error}' creating Module Console Port")
 
     def create_module_power_outlets(self, power_outlets, module_type):
-        existing_power_outlets = {str(item): item for item in self.netbox.dcim.power_outlet_templates.filter(moduletype_id=module_type)}
+        existing_power_outlets = {str(item): item for item in self.netbox.dcim.power_outlet_templates.filter(module_type_id=module_type)}
         to_create = self.get_module_type_ports_to_create(power_outlets, module_type, existing_power_outlets)
 
         if to_create:
@@ -416,7 +416,7 @@ class DeviceTypes:
                 self.handle.log(f"Error '{excep.error}' creating Module Power Outlet")
 
     def create_module_console_server_ports(self, console_server_ports, module_type):
-        existing_console_server_ports = {str(item): item for item in self.netbox.dcim.console_server_port_templates.filter(moduletype_id=module_type)}
+        existing_console_server_ports = {str(item): item for item in self.netbox.dcim.console_server_port_templates.filter(module_type_id=module_type)}
         to_create = self.get_module_type_ports_to_create(console_server_ports, module_type, existing_console_server_ports)
 
         if to_create:
@@ -442,7 +442,7 @@ class DeviceTypes:
                 self.handle.log(f"Error '{excep.error}' creating Module Rear Port")
 
     def create_module_front_ports(self, front_ports, module_type):
-        existing_front_ports = {str(item): item for item in self.netbox.dcim.front_port_templates.filter(moduletype_id=module_type)}
+        existing_front_ports = {str(item): item for item in self.netbox.dcim.front_port_templates.filter(module_type_id=module_type)}
         to_create = self.get_module_type_ports_to_create(front_ports, module_type, existing_front_ports)
 
         if to_create:


### PR DESCRIPTION
The fields for the device and module types are called `device_type_id` and `module_type_id` with an additional underscore.