### PR TITLE
Refactor and enable Docker build workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -18,16 +18,14 @@ jobs:
   build-and-push-images:
     runs-on: ubuntu-latest
     steps:
-      -
-        name: Checkout
-        uses: actions/checkout@v2
+
       -
         name: Docker meta
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v5
         with:
           images: |
-            ghcr.io/minitriga/Netbox-Device-Type-Library-Import
+            ghcr.io/${{ github.repository_owner }}/device-type-library-import
           tags: |
             type=raw,value=latest,enable=${{ endsWith(github.ref, github.event.repository.default_branch) }}
             type=ref,event=branch
@@ -37,24 +35,23 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
       - 
         name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v3
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
       -
         name: Login to GitHub Container Registry
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v1 
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       -
         name: Build and push
-        uses: docker/build-push-action@v2
+        uses: docker/bake-action@v6
         with:
-          context: .
           push: ${{ github.event_name != 'pull_request' }}
-          platforms: linux/amd64
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          files: |
+            ./docker-bake.hcl
+            cwd://${{ steps.meta.outputs.bake-file }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-alpine
+FROM python:3.13-alpine
 
 ENV REPO_URL=https://github.com/netbox-community/devicetype-library.git
 WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ docker build -t netbox-devicetype-import-library .
 Alternatively you can pull a pre-built image from Github Container Registry (ghcr.io):
 
 ```
-docker pull netbox-community/device-type-library-import
+docker pull ghcr.io/netbox-community/device-type-library-import
 ```
 
 The container supports the following env var as configuration :
@@ -92,7 +92,7 @@ The container supports the following env var as configuration :
 To run :
 
 ```
-docker run -e "NETBOX_URL=http://netbox:8080/" -e "NETBOX_TOKEN=98765434567890" netbox-community/device-type-library-import
+docker run -e "NETBOX_URL=http://netbox:8080/" -e "NETBOX_TOKEN=98765434567890" ghcr.io/netbox-community/device-type-library-import
 ```
 
 ## 🧑‍💻 Contributing

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ docker build -t netbox-devicetype-import-library .
 Alternatively you can pull a pre-built image from Github Container Registry (ghcr.io):
 
 ```
-docker pull ghcr.io/minitriga/netbox-device-type-library-import
+docker pull netbox-community/device-type-library-import
 ```
 
 The container supports the following env var as configuration :
@@ -92,7 +92,7 @@ The container supports the following env var as configuration :
 To run :
 
 ```
-docker run -e "NETBOX_URL=http://netbox:8080/" -e "NETBOX_TOKEN=98765434567890" ghcr.io/minitriga/netbox-device-type-library-import
+docker run -e "NETBOX_URL=http://netbox:8080/" -e "NETBOX_TOKEN=98765434567890" netbox-community/device-type-library-import
 ```
 
 ## 🧑‍💻 Contributing

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -10,6 +10,6 @@ target "default" {
 
 target "dev" {
     tags = [
-        "netbox-community/device-type-library-import:dev"
+        "ghcr.io/netbox-community/device-type-library-import:dev"
     ]
 }

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,0 +1,15 @@
+target "docker-metadata-action" {}
+
+target "default" {
+  inherits = ["docker-metadata-action"]
+  platforms = [
+    "linux/amd64",
+    "linux/arm64",
+  ]
+}
+
+target "dev" {
+    tags = [
+        "netbox-community/device-type-library-import:dev"
+    ]
+}


### PR DESCRIPTION
- Refactor `.github/workflows/docker.yml`
- Bump `Dockerfile` to use `python:v3.13-alpine`
- Publish `linux/amd64` and `linux/arm64` variants