### PR TITLE
Change regex string to raw string to avoid improper escape

### DIFF
--- a/repo.py
+++ b/repo.py
@@ -36,7 +36,7 @@ class DTLRepo:
         return os.path.join(self.get_absolute_path(), 'module-types')
 
     def slug_format(self, name):
-        return re_sub('\W+', '-', name.lower())
+        return re_sub(r'\W+', '-', name.lower())
 
     def pull_repo(self):
         try:


### PR DESCRIPTION
The regex string `'\W+'` causes a `SyntaxWarning` in Python 3.12 and later, since this is an invalid escape sequence. It will eventually become a `SyntaxError` in later versions. Changing this to a raw string will prevent it from being misinterpreted as an escape sequence.

Fixes #139 