### PR TITLE
Adding env variable to avoid updating existing images

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,5 +3,6 @@ NETBOX_TOKEN=
 REPO_URL=https://github.com/netbox-community/devicetype-library.git
 REPO_BRANCH=master
 IGNORE_SSL_ERRORS=False
+CHECK_IMAGES=False # enable it to avoid updating existing images
 #REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt # you should enable this if you are running on a linux system
 #SLUGS=c9300-48u isr4431 isr4331

--- a/netbox_api.py
+++ b/netbox_api.py
@@ -23,6 +23,7 @@ class NetBox:
         self.handle = settings.handle
         self.netbox = None
         self.ignore_ssl = settings.IGNORE_SSL_ERRORS
+        self.check_images = settings.CHECK_IMAGES
         self.modules = False
         self.new_filters = False
         self.connect_api()
@@ -59,7 +60,7 @@ class NetBox:
         if version_split[0] >= 4 and version_split[1] >= 1:
             self.new_filters = True
             self.handle.log(f'Netbox version {self.netbox.version} found. Using new filters.')
-    
+
     def get_manufacturers(self):
         return {str(item): item for item in self.netbox.dcim.manufacturers.all()}
 
@@ -142,9 +143,21 @@ class NetBox:
             if self.modules and 'module-bays' in device_type:
                 self.device_types.create_module_bays(device_type['module-bays'], dt.id)
 
-            # Finally, update images if any
             if saved_images:
-                self.device_types.upload_images(self.url, self.token, saved_images, dt.id)
+                if self.check_images:
+                    # Update images if any with existence check
+                    images_to_upload = {}
+                    for img_type, img_path in saved_images.items():
+                        if self.needs_image_update(dt.id, img_type):
+                            images_to_upload[img_type] = img_path
+                        else:
+                            self.handle.log(f'Image {img_type} already exists for {dt.model}, skipping upload')
+
+                    if images_to_upload:
+                        self.device_types.upload_images(self.url, self.token, images_to_upload, dt.id)
+                else:
+                    # Always update images if any
+                    self.device_types.upload_images(self.url, self.token, saved_images, dt.id)
 
     def create_module_types(self, module_types):
         all_module_types = {}
@@ -185,6 +198,21 @@ class NetBox:
             if "front-ports" in curr_mt:
                 self.device_types.create_module_front_ports(curr_mt["front-ports"], module_type_res.id)
 
+    def needs_image_update(self, dt_id: int, image_type: str) -> bool:
+        """Checks what the image needs to be updated"""
+        try:
+            device_type = self.netbox.dcim.device_types.get(dt_id)
+            current_image = getattr(device_type, image_type, None)
+            if not current_image:
+                return True
+
+            return False
+
+        except Exception as e:
+            self.log(f'Error checking image update for {dt_id}: {e}')
+            return True
+
+
 class DeviceTypes:
     def __new__(cls, *args, **kwargs):
         return super().__new__(cls)
@@ -202,7 +230,7 @@ class DeviceTypes:
 
     def get_power_ports(self, device_type):
         return {str(item): item for item in self.netbox.dcim.power_port_templates.filter(**{'device_type_id' if self.new_filters else 'devicetype_id': device_type})}
-      
+
     def get_rear_ports(self, device_type):
         return {str(item): item for item in self.netbox.dcim.rear_port_templates.filter(**{'device_type_id' if self.new_filters else 'devicetype_id': device_type})}
 

--- a/settings.py
+++ b/settings.py
@@ -11,6 +11,7 @@ REPO_BRANCH = os.getenv("REPO_BRANCH", default="master")
 NETBOX_URL = os.getenv("NETBOX_URL")
 NETBOX_TOKEN = os.getenv("NETBOX_TOKEN")
 IGNORE_SSL_ERRORS = (os.getenv("IGNORE_SSL_ERRORS", default="False") == "True")
+CHECK_IMAGES = (os.getenv("CHECK_IMAGES", default="False") == "True")
 REPO_PATH = f"{os.path.dirname(os.path.realpath(__file__))}/repo"
 
 # optionally load vendors through a comma separated list as env var


### PR DESCRIPTION
## Description:

- **Summary:** An environment variable has been added to control image loading. 
When setting the value `CHECK_IMAGES=False` (default value), the presence of images in the DeviceType object is not checked and the images are always updated. 
When setting `CHECK_IMAGES=True`, the image is checked and unnecessary loading does not occur.
    
- **What I changed:**
    - Updated .env, settings and `__init__.py` of Netbox class - added variable `CHECK_IMAGES`.
    - Modify `create_device_types` method and add new method `needs_image_update`.
 
- **Why:** 
Now, when downloading and updating DeviceType, images are always updated, which leads to the re-uploading of identical versions of images and new ChangeLog entries.
   